### PR TITLE
CASMPET-7013: Update the build to use a version pinned build image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ########### Build ##########
-FROM artifactory.algol60.net/docker.io/library/golang:alpine AS build
+FROM artifactory.algol60.net/docker.io/library/golang:1.17.3-alpine3.13 AS build
 
 RUN apk add --no-cache git build-base
 

--- a/runUnitTest.sh
+++ b/runUnitTest.sh
@@ -25,7 +25,7 @@
 
 set -ex
 
-docker run --rm -v "${WORKSPACE}":/mnt/workspace -w /mnt/workspace artifactory.algol60.net/docker.io/library/golang:alpine /bin/sh -c '
+docker run --rm -v "${WORKSPACE}":/mnt/workspace -w /mnt/workspace artifactory.algol60.net/docker.io/library/golang:1.17.3-alpine3.13 /bin/sh -c '
 set -ex -o pipefail
 
 echo "Unit Tests for Go"


### PR DESCRIPTION
## Summary and Scope

This just fixes the build issues with the spire-tokens image. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7013](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7013)

## Testing

### Tested on:

  * Jenkins

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

